### PR TITLE
Announcement

### DIFF
--- a/db/migrations/20200511023924-create-announcement.js
+++ b/db/migrations/20200511023924-create-announcement.js
@@ -34,11 +34,6 @@ module.exports = {
 					type: Sequelize.STRING,
 					allowNull: false,
 					defaultValue: 'info'
-				},
-				displayed: {
-					type: Sequelize.BOOLEAN,
-					allowNull: false,
-					defaultValue: true
 				}
 			},
 			{

--- a/db/migrations/20200511023924-create-announcement.js
+++ b/db/migrations/20200511023924-create-announcement.js
@@ -39,11 +39,6 @@ module.exports = {
 					type: Sequelize.BOOLEAN,
 					allowNull: false,
 					defaultValue: true
-				},
-				timestamp: {
-					type: Sequelize.DATE,
-					allowNull: false,
-					defaultValue: Sequelize.literal('NOW()')
 				}
 			},
 			{

--- a/db/migrations/20200511023924-create-announcement.js
+++ b/db/migrations/20200511023924-create-announcement.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const TABLE = 'Announcements';
+
+module.exports = {
+	up: (queryInterface, Sequelize) => {
+		return queryInterface.createTable(
+			TABLE,
+			{
+				id: {
+					allowNull: false,
+					autoIncrement: true,
+					primaryKey: true,
+					type: Sequelize.INTEGER
+				},
+				created_by: {
+					type: Sequelize.INTEGER,
+					onDelete: 'CASCADE',
+					allowNull: false,
+					references: {
+						model: 'Users',
+						key: 'id'
+					}
+				},
+				title: {
+					type: Sequelize.STRING,
+					allowNull: false
+				},
+				message: {
+					type: Sequelize.TEXT,
+					allowNull: false
+				},
+				type: {
+					type: Sequelize.STRING,
+					allowNull: false,
+					defaultValue: 'info'
+				},
+				displayed: {
+					type: Sequelize.BOOLEAN,
+					allowNull: false,
+					defaultValue: true
+				},
+				timestamp: {
+					type: Sequelize.DATE,
+					allowNull: false,
+					defaultValue: Sequelize.literal('NOW()')
+				}
+			},
+			{
+				timestamps: true,
+				underscored: true
+			}
+		);
+	},
+	down: (queryInterface) => queryInterface.dropTable(TABLE)
+};

--- a/db/migrations/20200511023924-create-announcement.js
+++ b/db/migrations/20200511023924-create-announcement.js
@@ -34,6 +34,16 @@ module.exports = {
 					type: Sequelize.STRING,
 					allowNull: false,
 					defaultValue: 'info'
+				},
+				created_at: {
+					allowNull: false,
+					type: Sequelize.DATE,
+					defaultValue: Sequelize.literal('NOW()')
+				},
+				updated_at: {
+					allowNull: false,
+					type: Sequelize.DATE,
+					defaultValue: Sequelize.literal('NOW()')
 				}
 			},
 			{

--- a/db/models/announcement.js
+++ b/db/models/announcement.js
@@ -30,11 +30,6 @@ module.exports = function(sequelize, DataTypes) {
 				allowNull: false,
 				defaultValue: 'info'
 			},
-			displayed: {
-				type: DataTypes.BOOLEAN,
-				allowNull: false,
-				defaultValue: true
-			},
 			created_at: {
 				allowNull: false,
 				type: DataTypes.DATE,

--- a/db/models/announcement.js
+++ b/db/models/announcement.js
@@ -33,12 +33,12 @@ module.exports = function(sequelize, DataTypes) {
 			created_at: {
 				allowNull: false,
 				type: DataTypes.DATE,
-				defaultValue: DataTypes.literal('NOW()')
+				defaultValue: DataTypes.NOW
 			},
 			updated_at: {
 				allowNull: false,
 				type: DataTypes.DATE,
-				defaultValue: DataTypes.literal('NOW()')
+				defaultValue: DataTypes.NOW
 			}
 		},
 		{

--- a/db/models/announcement.js
+++ b/db/models/announcement.js
@@ -29,16 +29,6 @@ module.exports = function(sequelize, DataTypes) {
 				type: DataTypes.STRING,
 				allowNull: false,
 				defaultValue: 'info'
-			},
-			created_at: {
-				allowNull: false,
-				type: DataTypes.DATE,
-				defaultValue: DataTypes.NOW
-			},
-			updated_at: {
-				allowNull: false,
-				type: DataTypes.DATE,
-				defaultValue: DataTypes.NOW
 			}
 		},
 		{

--- a/db/models/announcement.js
+++ b/db/models/announcement.js
@@ -1,0 +1,50 @@
+module.exports = function(sequelize, DataTypes) {
+	const Announcement = sequelize.define(
+		'Announcement',
+		{
+			id: {
+				allowNull: false,
+				autoIncrement: true,
+				primaryKey: true,
+				type: DataTypes.INTEGER
+			},
+			created_by: {
+				type: DataTypes.INTEGER,
+				onDelete: 'CASCADE',
+				allowNull: false,
+				references: {
+					model: 'Users',
+					key: 'id'
+				}
+			},
+			title: {
+				type: DataTypes.STRING,
+				allowNull: false
+			},
+			message: {
+				type: DataTypes.TEXT,
+				allowNull: false
+			},
+			type: {
+				type: DataTypes.STRING,
+				allowNull: false,
+				defaultValue: 'info'
+			},
+			displayed: {
+				type: DataTypes.BOOLEAN,
+				allowNull: false,
+				defaultValue: true
+			},
+			timestamp: {
+				type: DataTypes.DATE,
+				allowNull: false,
+				defaultValue: DataTypes.literal('NOW()')
+			}
+		},
+		{
+			timestamps: true,
+			underscored: true
+		}
+	);
+	return Announcement;
+};

--- a/db/models/announcement.js
+++ b/db/models/announcement.js
@@ -35,9 +35,14 @@ module.exports = function(sequelize, DataTypes) {
 				allowNull: false,
 				defaultValue: true
 			},
-			timestamp: {
-				type: DataTypes.DATE,
+			created_at: {
 				allowNull: false,
+				type: DataTypes.DATE,
+				defaultValue: DataTypes.literal('NOW()')
+			},
+			updated_at: {
+				allowNull: false,
+				type: DataTypes.DATE,
 				defaultValue: DataTypes.literal('NOW()')
 			}
 		},

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -50,6 +50,8 @@ model = sequelize.import('status', require('./status'));
 db[model.name] = model;
 model = sequelize.import('fee', require('./fee'));
 db[model.name] = model;
+model = sequelize.import('announcement', require('./announcement'));
+db[model.name] = model;
 
 Object.keys(db).forEach(function(modelName) {
 	if ('associate' in db[modelName]) {

--- a/plugins/announcement/helpers.js
+++ b/plugins/announcement/helpers.js
@@ -11,6 +11,11 @@ const postAnnouncement = (created_by, title, message, type) => {
 	});
 };
 
+const deleteAnnouncement = (id) => {
+	return Announcement.destroy({ id });
+};
+
 module.exports = {
-	postAnnouncement
+	postAnnouncement,
+	deleteAnnouncement
 };

--- a/plugins/announcement/helpers.js
+++ b/plugins/announcement/helpers.js
@@ -13,7 +13,11 @@ const postAnnouncement = (created_by, title, message, type) => {
 };
 
 const deleteAnnouncement = (id) => {
-	return Announcement.destroy({ id });
+	return Announcement.destroy({ where: { id } });
+};
+
+const findAnnouncement = (id) => {
+	return Announcement.findOne({ where: { id }});
 };
 
 const getAnnouncements = (pagination = {}, timeframe, ordering) => {
@@ -35,5 +39,6 @@ const getAnnouncements = (pagination = {}, timeframe, ordering) => {
 module.exports = {
 	postAnnouncement,
 	deleteAnnouncement,
+	findAnnouncement,
 	getAnnouncements
 };

--- a/plugins/announcement/helpers.js
+++ b/plugins/announcement/helpers.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { Announcement } = require('../../db/models');
+
+const postAnnouncement = (created_by, title, message, type) => {
+	return Announcement.create({
+		created_by,
+		title,
+		message,
+		type
+	});
+};
+
+module.exports = {
+	postAnnouncement
+};

--- a/plugins/announcement/helpers.js
+++ b/plugins/announcement/helpers.js
@@ -29,6 +29,9 @@ const getAnnouncements = (pagination = {}, timeframe, ordering) => {
 	}
 	let query = {
 		order,
+		attributes: {
+			exclude: ['created_by']
+		},
 		...pagination
 	};
 	if (timeframe) query.where.created_at = timeframe;

--- a/plugins/announcement/helpers.js
+++ b/plugins/announcement/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Announcement } = require('../../db/models');
+const { convertSequelizeCountAndRows } = require('../helpers/common');
 
 const postAnnouncement = (created_by, title, message, type) => {
 	return Announcement.create({
@@ -15,7 +16,24 @@ const deleteAnnouncement = (id) => {
 	return Announcement.destroy({ id });
 };
 
+const getAnnouncements = (pagination = {}, timeframe, ordering) => {
+	const order = [];
+	if (!ordering) {
+		order.push(['created_at', 'desc']);
+	} else {
+		order.push(ordering);
+	}
+	let query = {
+		order,
+		...pagination
+	};
+	if (timeframe) query.where.created_at = timeframe;
+	return Announcement.findAndCountAll(query)
+		.then(convertSequelizeCountAndRows);
+};
+
 module.exports = {
 	postAnnouncement,
-	deleteAnnouncement
+	deleteAnnouncement,
+	getAnnouncements
 };

--- a/plugins/announcement/index.js
+++ b/plugins/announcement/index.js
@@ -6,6 +6,7 @@ const { postAnnouncement, deleteAnnouncement, getAnnouncements, findAnnouncement
 const bodyParser = require('body-parser');
 const { logger, getPagination, getTimeframe, getOrdering } = require('../helpers/common');
 const { WRONG_TITLE, WRONG_MESSAGE, WRONG_TYPE, WRONG_ID } = require('./messages');
+const { WRONG_LIMIT, WRONG_PAGE, WRONG_ORDER_BY, WRONG_ORDER } = require('../helpers/messages');
 // const { sendEmail } = require('../../mail');
 // const { MAILTYPE } = require('../../mail/strings');
 
@@ -90,17 +91,17 @@ app.get('/plugins/announcements', (req, res) => {
 	const { limit, page, order_by, order, start_date, end_date } = req.query;
 
 	if (limit && !parseInt(limit)) {
-		logger.error('GET /plugins/announcements error', 'Value \'limit\' must be an integer');
-		return res.status(400).json({ message: 'Value \'limit\' must be an integer' });
+		logger.error('GET /plugins/announcements error', WRONG_LIMIT);
+		return res.status(400).json({ message: WRONG_LIMIT });
 	} else if (page && !parseInt(page)) {
-		logger.error('GET /plugins/announcements error', 'Value \'page\' must be an integer');
-		return res.status(400).json({ message: 'Value \'page\' must be an integer' });
+		logger.error('GET /plugins/announcements error', WRONG_PAGE);
+		return res.status(400).json({ message: WRONG_PAGE });
 	} else if (order_by && order_by.includes(' ')) {
-		logger.error('GET /plugins/announcements error', 'Value \'order_by\' cannot include whitespaces');
-		return res.status(400).json({ message: 'Value \'order_by\' cannot include whitespaces' });
+		logger.error('GET /plugins/announcements error', WRONG_ORDER_BY);
+		return res.status(400).json({ message: WRONG_ORDER_BY });
 	} else if (order && (order !== 'asc' || order!== 'desc')) {
-		logger.error('GET /plugins/announcements error', 'Value \'order\' must be one of: [\'asc\', \'desc\']');
-		return res.status(400).json({ message: 'Value \'order\' must be one of: [\'asc\', \'desc\']' });
+		logger.error('GET /plugins/announcements error', WRONG_ORDER);
+		return res.status(400).json({ message: WRONG_ORDER });
 	}
 
 	logger.info(

--- a/plugins/announcement/index.js
+++ b/plugins/announcement/index.js
@@ -5,6 +5,7 @@ const { verifyToken, checkScopes } = require('../helpers/auth');
 const { postAnnouncement, deleteAnnouncement, getAnnouncements, findAnnouncement } = require('./helpers');
 const bodyParser = require('body-parser');
 const { logger, getPagination, getTimeframe, getOrdering } = require('../helpers/common');
+const { WRONG_TITLE, WRONG_MESSAGE, WRONG_TYPE, WRONG_ID } = require('./messages');
 // const { sendEmail } = require('../../mail');
 // const { MAILTYPE } = require('../../mail/strings');
 
@@ -21,14 +22,14 @@ app.post('/plugins/announcement', [verifyToken, bodyParser.json()], (req, res) =
 	let { title, message, type } = req.body;
 
 	if (!title || typeof title !== 'string') {
-		logger.error('POST /plugins/announcement error', 'Value \'title\' is required and must be a string');
-		return res.status(400).json({ message: 'Value \'title\' is required and must be a string' });
+		logger.error('POST /plugins/announcement error', WRONG_TITLE);
+		return res.status(400).json({ message: WRONG_TITLE });
 	} else if (!message || typeof message !== 'string') {
-		logger.error('POST /plugins/announcement error', 'Value \'message\' is required and must be a string');
-		return res.status(400).json({ message: 'Value \'message\' is required and must be a string' });
+		logger.error('POST /plugins/announcement error', WRONG_MESSAGE);
+		return res.status(400).json({ message: WRONG_MESSAGE });
 	} else if (type && typeof type !== 'string') {
-		logger.error('POST /plugins/announcement error', 'Value \'type\' must be a string');
-		return res.status(400).json({ message: 'Value \'type\' must be a string' });
+		logger.error('POST /plugins/announcement error', WRONG_TYPE);
+		return res.status(400).json({ message: WRONG_TYPE });
 	}
 
 	if (!type) type = 'info';
@@ -63,8 +64,8 @@ app.delete('/plugins/announcement', verifyToken, (req, res) => {
 	const id = parseInt(req.query.id);
 
 	if (!id) {
-		logger.error('DELETE /plugins/announcement error', 'Value \'id\' is required and must be an integer');
-		return res.status(400).json({ message: 'Value \'id\' is required and must be an integer' });
+		logger.error('DELETE /plugins/announcement error', WRONG_ID);
+		return res.status(400).json({ message: WRONG_ID });
 	}
 
 	findAnnouncement(id)
@@ -85,8 +86,22 @@ app.delete('/plugins/announcement', verifyToken, (req, res) => {
 		});
 });
 
-app.get('/plugins/annoucements', (req, res) => {
+app.get('/plugins/announcements', (req, res) => {
 	const { limit, page, order_by, order, start_date, end_date } = req.query;
+
+	if (limit && !parseInt(limit)) {
+		logger.error('GET /plugins/announcements error', 'Value \'limit\' must be an integer');
+		return res.status(400).json({ message: 'Value \'limit\' must be an integer' });
+	} else if (page && !parseInt(page)) {
+		logger.error('GET /plugins/announcements error', 'Value \'page\' must be an integer');
+		return res.status(400).json({ message: 'Value \'page\' must be an integer' });
+	} else if (order_by && order_by.includes(' ')) {
+		logger.error('GET /plugins/announcements error', 'Value \'order_by\' cannot include whitespaces');
+		return res.status(400).json({ message: 'Value \'order_by\' cannot include whitespaces' });
+	} else if (order && (order !== 'asc' || order!== 'desc')) {
+		logger.error('GET /plugins/announcements error', 'Value \'order\' must be one of: [\'asc\', \'desc\']');
+		return res.status(400).json({ message: 'Value \'order\' must be one of: [\'asc\', \'desc\']' });
+	}
 
 	logger.info(
 		'GET /plugins/announcements',

--- a/plugins/announcement/index.js
+++ b/plugins/announcement/index.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const app = require('../index');
+const { verifyToken, checkScopes } = require('../helpers/auth');
+const { postAnnouncement } = require('./helpers');
+const bodyParser = require('body-parser');
+const { logger } = require('../helpers/common');
+// const { sendEmail } = require('../../mail');
+// const { MAILTYPE } = require('../../mail/strings');
+
+app.post('/plugins/announcement', [verifyToken, bodyParser.json()], (req, res) => {
+	const endpointScopes = ['admin'];
+	const scopes = req.auth.scopes;
+	checkScopes(endpointScopes, scopes);
+
+	logger.verbose(
+		'POST /plugins/announcement auth',
+		req.auth.sub
+	);
+
+	const { title, message, type } = req.body;
+
+	logger.info(
+		'POST /plugins/announcement announcement',
+		title,
+		type
+	);
+
+	postAnnouncement(req.auth.sub.id, title, message, type)
+		.then((announcement) => {
+			res.json(announcement);
+		})
+		.catch((error) => {
+			logger.error('POST /plugins/announcement error', error.message);
+			res.status(error.status || 400).json({ message: error.message });
+		});
+});

--- a/plugins/announcement/index.js
+++ b/plugins/announcement/index.js
@@ -18,7 +18,17 @@ app.post('/plugins/announcement', [verifyToken, bodyParser.json()], (req, res) =
 		req.auth.sub
 	);
 
-	const { title, message, type } = req.body;
+	let { title, message, type } = req.body;
+
+	if (!title || typeof title !== 'string') {
+		return res.status(400).json({ message: 'Value \'title\' is required and must be a string' });
+	} else if (!message || typeof message !== 'string') {
+		return res.status(400).json({ message: 'Value \'message\' is required and must be a string' });
+	} else if (type && typeof type !== 'string') {
+		return res.status(400).json({ message: 'Value \'type\' must be a string' });
+	}
+
+	if (!type) type = 'info';
 
 	logger.info(
 		'POST /plugins/announcement announcement',

--- a/plugins/announcement/index.js
+++ b/plugins/announcement/index.js
@@ -2,7 +2,7 @@
 
 const app = require('../index');
 const { verifyToken, checkScopes } = require('../helpers/auth');
-const { postAnnouncement } = require('./helpers');
+const { postAnnouncement, deleteAnnouncement } = require('./helpers');
 const bodyParser = require('body-parser');
 const { logger } = require('../helpers/common');
 // const { sendEmail } = require('../../mail');
@@ -28,10 +28,34 @@ app.post('/plugins/announcement', [verifyToken, bodyParser.json()], (req, res) =
 
 	postAnnouncement(req.auth.sub.id, title, message, type)
 		.then((announcement) => {
+			logger.debug('POST /plugins/announcement success ID: ', announcement.dataValues.id);
 			res.json(announcement);
 		})
 		.catch((error) => {
 			logger.error('POST /plugins/announcement error', error.message);
+			res.status(error.status || 400).json({ message: error.message });
+		});
+});
+
+app.delete('/plugins/announcement/:id', [verifyToken, bodyParser.json()], (req, res) => {
+	const endpointScopes = ['admin'];
+	const scopes = req.auth.scopes;
+	checkScopes(endpointScopes, scopes);
+
+	logger.verbose(
+		'DELETE /plugins/announcement auth',
+		req.auth.sub
+	);
+
+	const id = req.params.id;
+
+	deleteAnnouncement(id)
+		.then(() => {
+			logger.debug('DELETE /plugins/announcement success ID: ', id);
+			res.json(`Announcement ${id} successfully deleted`);
+		})
+		.catch((error) => {
+			logger.error('DELETE /plugins/announcement error', error.message);
 			res.status(error.status || 400).json({ message: error.message });
 		});
 });

--- a/plugins/announcement/messages.js
+++ b/plugins/announcement/messages.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.WRONG_TITLE = 'Value \'title\' is required and must be a string';
+exports.WRONG_MESSAGE = 'Value \'message\' is required and must be a string';
+exports.WRONG_TYPE = 'Value \'type\' must be a string';
+exports.WRONG_ID = 'Value \'id\' is required and must be an integer';

--- a/plugins/announcement/package.json
+++ b/plugins/announcement/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "announcement",
+	"version": "0.1.0",
+	"dependencies": {}
+}

--- a/plugins/helpers/common.js
+++ b/plugins/helpers/common.js
@@ -58,22 +58,22 @@ const isUrl = (url) => {
 	return pattern.test(url);
 };
 
-const getPagination = (limit = { value: 50 }, page = { value: 1 }) => {
+const getPagination = (limit = 50, page = 1) => {
 	let _limit = 50;
 	let _page = 1;
 	logger.debug('helpers/common/getPagination', _limit, _page);
-	if (limit.value) {
-		if (limit.value > 50) {
+	if (limit) {
+		if (limit > 50) {
 			_limit = 50;
-		} else if (limit.value <= 0) {
+		} else if (limit <= 0) {
 			_limit = 1;
 		} else {
-			_limit = limit.value;
+			_limit = limit;
 		}
 	}
 
-	if (page.value && page.value >= 0) {
-		_page = page.value;
+	if (page && page >= 0) {
+		_page = page;
 	}
 	logger.debug('helpers/common/getPagination', _limit, _page);
 	return {
@@ -93,33 +93,33 @@ const convertSequelizeCountAndRows = (data) => {
 	};
 };
 
-const getTimeframe = (start_date = { value: undefined }, end_date = { value: undefined }) => {
+const getTimeframe = (start_date = undefined, end_date = undefined) => {
 	logger.debug(
 		'helpers/common/getTimeframe',
 		'stat_date: ',
-		start_date.value,
+		start_date,
 		'end_date: ',
-		end_date.value
+		end_date
 	);
 	let timestamp = {};
-	if (start_date.value) timestamp['$gte'] = start_date.value;
-	if (end_date.value) timestamp['$lte'] = end_date.value;
+	if (start_date) timestamp['$gte'] = start_date;
+	if (end_date) timestamp['$lte'] = end_date;
 	if (Object.entries(timestamp).length === 0) return undefined;
 	return timestamp;
 };
 
-const getOrdering = (order_by = { value: undefined }, order = { value: undefined }, attr = []) => {
+const getOrdering = (order_by = undefined, order = undefined) => {
 	logger.debug(
 		'helpers/common/getOrdering',
 		'order_by: ',
-		order_by.value,
+		order_by,
 		'order: ',
-		order.value
+		order
 	);
-	if (!order_by.value || !attr.includes(order_by.value)) {
+	if (!order_by) {
 		return undefined;
 	} else {
-		return [order_by.value, order.value || 'desc'];
+		return [order_by, order || 'desc'];
 	}
 };
 

--- a/plugins/helpers/common.js
+++ b/plugins/helpers/common.js
@@ -58,8 +58,77 @@ const isUrl = (url) => {
 	return pattern.test(url);
 };
 
+const getPagination = (limit = { value: 50 }, page = { value: 1 }) => {
+	let _limit = 50;
+	let _page = 1;
+	logger.debug('helpers/common/getPagination', _limit, _page);
+	if (limit.value) {
+		if (limit.value > 50) {
+			_limit = 50;
+		} else if (limit.value <= 0) {
+			_limit = 1;
+		} else {
+			_limit = limit.value;
+		}
+	}
+
+	if (page.value && page.value >= 0) {
+		_page = page.value;
+	}
+	logger.debug('helpers/common/getPagination', _limit, _page);
+	return {
+		limit: _limit,
+		offset: _limit * (_page - 1)
+	};
+};
+
+const convertSequelizeCountAndRows = (data) => {
+	return {
+		count: data.count,
+		data: data.rows.map((row) => {
+			const item = Object.assign({}, row.dataValues);
+			// delete item.id;
+			return item;
+		})
+	};
+};
+
+const getTimeframe = (start_date = { value: undefined }, end_date = { value: undefined }) => {
+	logger.debug(
+		'helpers/common/getTimeframe',
+		'stat_date: ',
+		start_date.value,
+		'end_date: ',
+		end_date.value
+	);
+	let timestamp = {};
+	if (start_date.value) timestamp['$gte'] = start_date.value;
+	if (end_date.value) timestamp['$lte'] = end_date.value;
+	if (Object.entries(timestamp).length === 0) return undefined;
+	return timestamp;
+};
+
+const getOrdering = (order_by = { value: undefined }, order = { value: undefined }, attr = []) => {
+	logger.debug(
+		'helpers/common/getOrdering',
+		'order_by: ',
+		order_by.value,
+		'order: ',
+		order.value
+	);
+	if (!order_by.value || !attr.includes(order_by.value)) {
+		return undefined;
+	} else {
+		return [order_by.value, order.value || 'desc'];
+	}
+};
+
 module.exports = {
 	logger,
 	updateConstants,
-	isUrl
+	isUrl,
+	getPagination,
+	getOrdering,
+	getTimeframe,
+	convertSequelizeCountAndRows
 };

--- a/plugins/helpers/messages.js
+++ b/plugins/helpers/messages.js
@@ -6,3 +6,7 @@ exports.TOKEN_EXPIRED = 'Token is expired';
 exports.INVALID_TOKEN = 'Token is invalid';
 exports.MISSING_HEADER = 'Authorization header is missing';
 exports.DEACTIVATED_USER = 'This account is deactivated';
+exports.WRONG_LIMIT = 'Value \'limit\' must be an integer';
+exports.WRONG_PAGE = 'Value \'page\' must be an integer';
+exports.WRONG_ORDER_BY = 'Value \'order_by\' cannot include whitespaces';
+exports.WRONG_ORDER = 'Value \'order\' must be one of: [\'asc\', \'desc\']';


### PR DESCRIPTION
`POST /plugins/announcement`
- Requires body with values `title`, `message` and (optional) `type`
- Only admins can create

`DELETE /plugins/announcement`
- Requires query parameter `id` of the announcement being deleted
- Only admins can delete

`GET /plugins/announcements`
- Anyone can access this endpoint
- Accepts query parameters `limit`, `page`, `order_by`, `order`, `start_date`, `end_date`
- Excludes attribute `created_by`



Had to fix the migration and model files for `Announcement`. `created_at` and `updated_at` were originally in the model file.
Added more helper functions and messages for this particular PR. These will all be moved to the new library.