### PR TITLE
Vault update

### DIFF
--- a/plugins/announcement/index.js
+++ b/plugins/announcement/index.js
@@ -6,18 +6,22 @@ const { postAnnouncement, deleteAnnouncement, getAnnouncements, findAnnouncement
 const bodyParser = require('body-parser');
 const { logger, getPagination, getTimeframe, getOrdering, updatePluginConstant, maskSecrets } = require('../helpers/common');
 const { WRONG_TITLE, WRONG_MESSAGE, WRONG_TYPE, WRONG_ID } = require('./messages');
-const { WRONG_LIMIT, WRONG_PAGE, WRONG_ORDER_BY, WRONG_ORDER } = require('../helpers/messages');
+const { WRONG_LIMIT, WRONG_PAGE, WRONG_ORDER_BY, WRONG_ORDER, NOT_AUTHORIZED } = require('../helpers/messages');
 const { GET_SECRETS } = require('../../constants');
 
 app.get('/plugins/announcement/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/announcement/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/announcement/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('announcement', GET_SECRETS().plugins.announcement) || {});
@@ -29,12 +33,16 @@ app.get('/plugins/announcement/constant', verifyToken, (req, res) => {
 app.put('/plugins/announcement/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/announcement/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/announcement/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/announcement/constant error', 'Must provide key to update');
@@ -58,12 +66,16 @@ app.put('/plugins/announcement/constant', [verifyToken, bodyParser.json()], (req
 app.post('/plugins/announcement', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /plugins/announcement auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/announcement error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	let { title, message, type } = req.body;
 
@@ -100,12 +112,16 @@ app.post('/plugins/announcement', [verifyToken, bodyParser.json()], (req, res) =
 app.delete('/plugins/announcement', verifyToken, (req, res) => {
 	const endpointScopes = ['admin'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'DELETE /plugins/announcement auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('DELETE /plugins/announcement error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const id = parseInt(req.query.id);
 

--- a/plugins/bank/index.js
+++ b/plugins/bank/index.js
@@ -7,6 +7,7 @@ const { addBankAccount, adminAddUserBanks, approveBankAccount, rejectBankAccount
 const { USER_NOT_FOUND, DEFAULT_REJECTION_NOTE } = require('./messages');
 const bodyParser = require('body-parser');
 const { logger, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const { sendEmail } = require('../../mail');
 const { MAILTYPE } = require('../../mail/strings');
 const { GET_SECRETS } = require('../../constants');
@@ -14,12 +15,16 @@ const { GET_SECRETS } = require('../../constants');
 app.get('/plugins/bank/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/bank/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/bank/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('bank', GET_SECRETS().plugins.bank) || {});
@@ -31,12 +36,16 @@ app.get('/plugins/bank/constant', verifyToken, (req, res) => {
 app.put('/plugins/bank/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/bank/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/bank/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/bank/constant error', 'Must provide key to update');
@@ -60,12 +69,16 @@ app.put('/plugins/bank/constant', [verifyToken, bodyParser.json()], (req, res) =
 app.post('/plugins/bank/user', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['user'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /bank/user auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/bank/user error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const email = req.auth.sub.email;
 	const bank_account = req.body;
@@ -91,12 +104,16 @@ app.post('/plugins/bank/user', [verifyToken, bodyParser.json()], (req, res) => {
 app.post('/plugins/bank/admin', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'supervisor', 'support', 'kyc'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /bank/admin auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/bank/admin error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { bank_account } = req.body;
 	const id = req.query.user_id;
@@ -124,12 +141,16 @@ app.post('/plugins/bank/admin', [verifyToken, bodyParser.json()], (req, res) => 
 app.post('/plugins/bank/verify', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'supervisor', 'support', 'kyc'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /bank/verify auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/bank/verify error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { user_id, bank_id } = req.body;
 
@@ -166,12 +187,16 @@ app.post('/plugins/bank/verify', [verifyToken, bodyParser.json()], (req, res) =>
 app.post('/plugins/bank/revoke', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'supervisor', 'support', 'kyc'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /bank/revoke auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/bank/revoke error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { user_id, bank_id } = req.body;
 	let { message } = req.body || DEFAULT_REJECTION_NOTE;

--- a/plugins/chat/index.js
+++ b/plugins/chat/index.js
@@ -4,17 +4,22 @@ const app = require('../index');
 const { verifyToken, checkScopes } = require('../helpers/auth');
 const { GET_SECRETS } = require('../../constants');
 const { logger, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const bodyParser = require('body-parser');
 
 app.get('/plugins/chat/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/chat/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/chat/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('chat', GET_SECRETS().plugins.chat) || {});
@@ -26,12 +31,16 @@ app.get('/plugins/chat/constant', verifyToken, (req, res) => {
 app.put('/plugins/chat/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/chat/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/chat/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/chat/constant error', 'Must provide key to update');

--- a/plugins/constants.js
+++ b/plugins/constants.js
@@ -60,3 +60,5 @@ exports.ERC_TOKENS = [
 	'xaut',
 	'busd'
 ];
+
+exports.VAULT_ENDPOINT = 'https://api.vault.bitholla.com/v1';

--- a/plugins/freshdesk/index.js
+++ b/plugins/freshdesk/index.js
@@ -4,17 +4,22 @@ const app = require('../index');
 const { verifyToken, checkScopes } = require('../helpers/auth');
 const { GET_SECRETS } = require('../../constants');
 const { logger, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const bodyParser = require('body-parser');
 
 app.get('/plugins/freshdesk/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/freshdesk/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/freshdesk/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('freshdesk', GET_SECRETS().plugins.freshdesk) || {});
@@ -26,12 +31,16 @@ app.get('/plugins/freshdesk/constant', verifyToken, (req, res) => {
 app.put('/plugins/freshdesk/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/chat/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/freshdesk/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/freshdesk/constant error', 'Must provide key to update');

--- a/plugins/helpers/auth.js
+++ b/plugins/helpers/auth.js
@@ -3,14 +3,14 @@
 const jwt = require('jsonwebtoken');
 const { SECRET, ISSUER, GET_FROZEN_USERS } = require('../../constants');
 const { intersection } = require('lodash');
-const { ACCESS_DENIED, NOT_AUTHORIZED, TOKEN_EXPIRED, INVALID_TOKEN, MISSING_HEADER, DEACTIVATED_USER } = require('./messages');
+const { ACCESS_DENIED, TOKEN_EXPIRED, INVALID_TOKEN, MISSING_HEADER, DEACTIVATED_USER } = require('./messages');
 
 /**
 	* Middleware function used for verifying tokens being passed by client in Authorization header. Format: Bearer <token>
 */
 const verifyToken = (req, res, next) => {
 	const sendError = (msg) => {
-		return req.res.status(403).json({ message: ACCESS_DENIED(msg)});
+		return req.res.status(403).json({ message: ACCESS_DENIED(msg) });
 	};
 
 	const token = req.headers['authorization'];
@@ -49,7 +49,9 @@ const verifyToken = (req, res, next) => {
 */
 const checkScopes = (endpointScopes, userScopes) => {
 	if (intersection(endpointScopes, userScopes).length === 0) {
-		throw new Error(NOT_AUTHORIZED);
+		return false;
+	} else {
+		return true;
 	}
 };
 

--- a/plugins/kyc/index.js
+++ b/plugins/kyc/index.js
@@ -28,17 +28,22 @@ const { cloneDeep, omit } = require('lodash');
 const { ROLES } = require('../../constants');
 const { all } = require('bluebird');
 const { logger, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const { GET_SECRETS } = require('../../constants');
 
 app.get('/plugins/kyc/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/kyc/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/kyc/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('s3', GET_SECRETS().plugins.s3) || {});
@@ -50,12 +55,16 @@ app.get('/plugins/kyc/constant', verifyToken, (req, res) => {
 app.put('/plugins/kyc/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/kyc/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/kyc/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/kyc/constant error', 'Must provide key to update');
@@ -79,12 +88,16 @@ app.put('/plugins/kyc/constant', [verifyToken, bodyParser.json()], (req, res) =>
 app.put('/plugins/kyc/user', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['user'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/kyc/user',
 		req.body
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/kyc/user error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const email = req.auth.sub.email;
 	const editUser = req.body;
@@ -123,12 +136,16 @@ app.put('/plugins/kyc/user', [verifyToken, bodyParser.json()], (req, res) => {
 app.put('/plugins/kyc/admin', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'supervisor', 'support'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/kyc/admin',
 		req.auth
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/kyc/admin error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const ip = req.headers['x-real-ip'];
 	const domain = req.headers['x-real-origin'];
@@ -237,9 +254,13 @@ app.put('/plugins/kyc/admin', [verifyToken, bodyParser.json()], (req, res) => {
 app.post('/plugins/kyc/user/upload', [verifyToken, multerMiddleware], (req, res) => {
 	const endpointScopes = ['user'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose('POST /plugins/kyc/user/upload auth', req.auth.sub);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/kyc/user/upload error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { id, email } = req.auth.sub;
 	let { front, back, proof_of_residency } = req.files;
@@ -337,9 +358,13 @@ app.post('/plugins/kyc/user/upload', [verifyToken, multerMiddleware], (req, res)
 app.post('/plugins/kyc/admin/upload', [verifyToken, multerMiddleware], (req, res) => {
 	const endpointScopes = ['admin', 'supervisor'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose('POST /plugins/kyc/admin/upload auth', req.auth.sub);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/kyc/admin/upload error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	let { front, back, proof_of_residency } = req.files;
 	if (front) front = front[0];
@@ -448,9 +473,13 @@ app.post('/plugins/kyc/admin/upload', [verifyToken, multerMiddleware], (req, res
 app.get('/plugins/kyc/id', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'supervisor', 'support', 'kyc'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose('GET /plugins/kyc/id auth', req.auth.sub);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/kyc/id error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { email, id } = req.query;
 	const where = {};
@@ -478,12 +507,16 @@ app.get('/plugins/kyc/id', verifyToken, (req, res) => {
 app.post('/plugins/kyc/id/verify', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'supervisor', 'support', 'kyc'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /plugins/kyc/id/verify auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/kyc/id/verify error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { user_id } = req.body;
 
@@ -522,12 +555,16 @@ app.post('/plugins/kyc/id/verify', [verifyToken, bodyParser.json()], (req, res) 
 app.post('/plugins/kyc/id/revoke', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'supervisor', 'support', 'kyc'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /plugins/kyc/id/revoke auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/kyc/id/revoke error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { user_id } = req.body;
 	const { message } = req.body || DEFAULT_REJECTION_NOTE;

--- a/plugins/kyc/package-lock.json
+++ b/plugins/kyc/package-lock.json
@@ -139,9 +139,9 @@
 			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"media-typer": {
 			"version": "0.3.0",

--- a/plugins/sms/index.js
+++ b/plugins/sms/index.js
@@ -7,6 +7,7 @@ const PhoneNumber = require('awesome-phonenumber');
 const bodyParser = require('body-parser');
 const { createSMSCode, storeSMSCode, checkSMSCode, deleteSMSCode, sendSMS, updateUserPhoneNumber } = require('./helpers');
 const { logger, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const {
 	SMS_INVALID_PHONE,
 	SMS_SUCCESS,
@@ -20,12 +21,16 @@ const { GET_SECRETS } = require('../../constants');
 app.get('/plugins/sms/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/sms/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/sms/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('sns', GET_SECRETS().plugins.sns) || {});
@@ -37,12 +42,16 @@ app.get('/plugins/sms/constant', verifyToken, (req, res) => {
 app.put('/plugins/sms/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/sms/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/sms/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/sms/constant error', 'Must provide key to update');
@@ -66,12 +75,16 @@ app.put('/plugins/sms/constant', [verifyToken, bodyParser.json()], (req, res) =>
 app.get('/plugins/sms/verify', verifyToken, (req, res) => {
 	const endpointScopes = ['user'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /sms/verify auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/sms/verify error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const phoneNumber = new PhoneNumber(req.query.phone);
 	const { id } = req.auth.sub;
@@ -119,12 +132,16 @@ app.get('/plugins/sms/verify', verifyToken, (req, res) => {
 app.post('/plugins/sms/verify', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['user'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /sms/verify auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/sms/verify error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const { id } = req.auth.sub;
 	const { code } = req.body;

--- a/plugins/sms/package-lock.json
+++ b/plugins/sms/package-lock.json
@@ -61,9 +61,9 @@
 			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"punycode": {
 			"version": "1.3.2",

--- a/plugins/vault/crons/checkWithdrawals.js
+++ b/plugins/vault/crons/checkWithdrawals.js
@@ -4,7 +4,8 @@ const { Deposit, User, sequelize } = require('../../../db/models');
 const rp = require('request-promise');
 const { each } = require('lodash');
 const { all, delay } = require('bluebird');
-const { VAULT_ENDPOINT, GET_CONFIGURATION, GET_SECRETS } = require('../../../constants');
+const { GET_CONFIGURATION, GET_SECRETS } = require('../../../constants');
+const { VAULT_ENDPOINT } = require('../../constants');
 const mathjs = require('mathjs');
 const { loggerDeposits } = require('../../../config/logger');
 const VAULT_NAME = () => GET_SECRETS().vault.name;
@@ -67,7 +68,7 @@ const checkWithdrawals = () => {
 						qs: {
 							txid
 						},
-						uri: `${VAULT_ENDPOINT}/${VAULT_WALLET(txids[txid][0].currency)}/transactions`,
+						uri: `${VAULT_ENDPOINT}/wallet/${VAULT_WALLET(txids[txid][0].currency)}/transactions`,
 						json: true
 					};
 					return delay(500 * i)

--- a/plugins/vault/crons/processWithdrawals.js
+++ b/plugins/vault/crons/processWithdrawals.js
@@ -4,8 +4,8 @@ const { Deposit, sequelize, User, Sequelize } = require('../../../db/models');
 const rp = require('request-promise');
 const { each } = require('lodash');
 const { all, delay } = require('bluebird');
-const { VAULT_ENDPOINT, GET_CONFIGURATION, GET_SECRETS } = require('../../../constants');
-const { ERC_TOKENS } = require('../../constants');
+const { GET_CONFIGURATION, GET_SECRETS } = require('../../../constants');
+const { ERC_TOKENS, VAULT_ENDPOINT } = require('../../constants');
 const moment = require('moment');
 const { loggerDeposits } = require('../../../config/logger');
 const mathjs = require('mathjs');
@@ -134,7 +134,7 @@ const processWithdrawals = () => {
 										amount: getAmount(withdrawal.amount, withdrawal.fee)
 									}
 								},
-								uri: `${VAULT_ENDPOINT}/${VAULT_WALLET(withdrawal.currency)}/withdraw/simple`,
+								uri: `${VAULT_ENDPOINT}/wallet/${VAULT_WALLET(withdrawal.currency)}/withdraw/simple`,
 								json: true
 							},
 							dbWithdrawals: [withdrawal]
@@ -167,7 +167,7 @@ const processWithdrawals = () => {
 									};
 								})
 							},
-							uri: `${VAULT_ENDPOINT}/${VAULT_WALLET('btc')}/withdraw/batch`,
+							uri: `${VAULT_ENDPOINT}/wallet/${VAULT_WALLET('btc')}/withdraw/batch`,
 							json: true,
 						},
 						dbWithdrawals: btcWithdrawals
@@ -189,7 +189,7 @@ const processWithdrawals = () => {
 									};
 								})
 							},
-							uri: `${VAULT_ENDPOINT}/${VAULT_WALLET('bch')}/withdraw/batch`,
+							uri: `${VAULT_ENDPOINT}/wallet/${VAULT_WALLET('bch')}/withdraw/batch`,
 							json: true
 						},
 						dbWithdrawals: bchWithdrawals

--- a/plugins/vault/helpers.js
+++ b/plugins/vault/helpers.js
@@ -7,7 +7,7 @@ const { intersection, union, each } = require('lodash');
 const WEBHOOK_URL = (coin) => `${API_HOST}/v1/deposit/${coin}`;
 const WALLET_NAME = (name, coin) => `${name}-${coin}`;
 const { all, delay } = require('bluebird');
-const { updateConstants, logger, sleep } = require('../helpers/common');
+const { updatePluginConstant, logger, sleep } = require('../helpers/common');
 const cron = require('node-cron');
 const { processWithdrawals } = require('./crons/processWithdrawals');
 const { lockWithdrawals } = require('./crons/lockWithdrawals');
@@ -36,15 +36,11 @@ const cronTask = cron.schedule('* * * * *', () => {
 
 const updateVaultValues = (name, key, secret, connect = true) => {
 	logger.debug('/plugins/vault/helpers updateVaultValues');
-	return updateConstants({
-		secrets: {
-			vault: {
-				name: name === undefined ? GET_SECRETS().vault.name : name,
-				key: key === undefined ? GET_SECRETS().vault.key : key,
-				secret: secret === undefined ? GET_SECRETS().vault.secret : secret,
-				connected_coins: connect ? GET_SECRETS().vault.connected_coins : []
-			}
-		}
+	return updatePluginConstant('vault', {
+		name: name === undefined ? GET_SECRETS().vault.name : name,
+		key: key === undefined ? GET_SECRETS().vault.key : key,
+		secret: secret === undefined ? GET_SECRETS().vault.secret : secret,
+		connected_coins: connect ? GET_SECRETS().vault.connected_coins : []
 	});
 };
 
@@ -163,13 +159,9 @@ const checkWebhook = (wallet, vaultConfig) => {
 
 const addVaultCoinConnection = (coins, vaultConfig) => {
 	logger.debug('/plugins/vault/helpers addVaultCoinConnection', coins);
-	return updateConstants({
-		secrets: {
-			vault: {
-				...vaultConfig,
-				connected_coins: union(vaultConfig.connected_coins, coins)
-			}
-		}
+	return updatePluginConstant('vault', {
+		...vaultConfig,
+		connected_coins: union(vaultConfig.connected_coins, coins)
 	});
 };
 

--- a/plugins/vault/helpers.js
+++ b/plugins/vault/helpers.js
@@ -11,6 +11,7 @@ const { updatePluginConstant, logger, sleep } = require('../helpers/common');
 const cron = require('node-cron');
 const { processWithdrawals } = require('./crons/processWithdrawals');
 const { lockWithdrawals } = require('./crons/lockWithdrawals');
+const { resolve } = require('bluebird');
 // const { checkWithdrawals } = require('./crons/checkWithdrawals');
 
 const withdrawalCron = async () => {
@@ -36,12 +37,16 @@ const cronTask = cron.schedule('* * * * *', () => {
 
 const updateVaultValues = (name, key, secret, connect = true) => {
 	logger.debug('/plugins/vault/helpers updateVaultValues');
-	return updatePluginConstant('vault', {
-		name: name === undefined ? GET_SECRETS().vault.name : name,
-		key: key === undefined ? GET_SECRETS().vault.key : key,
-		secret: secret === undefined ? GET_SECRETS().vault.secret : secret,
-		connected_coins: connect ? GET_SECRETS().vault.connected_coins : []
-	});
+	if (name === undefined && key === undefined && secret === undefined) {
+		return resolve();
+	} else {
+		return updatePluginConstant('vault', {
+			name: name === undefined ? GET_SECRETS().vault.name : name,
+			key: key === undefined ? GET_SECRETS().vault.key : key,
+			secret: secret === undefined ? GET_SECRETS().vault.secret : secret,
+			connected_coins: connect ? GET_SECRETS().vault.connected_coins : []
+		});
+	}
 };
 
 const crossCheckCoins = (coins) => {

--- a/plugins/vault/helpers.js
+++ b/plugins/vault/helpers.js
@@ -39,9 +39,9 @@ const updateVaultValues = (name, key, secret, connect = true) => {
 	return updateConstants({
 		secrets: {
 			vault: {
-				name,
-				key,
-				secret,
+				name: name === undefined ? GET_SECRETS().vault.name : name,
+				key: key === undefined ? GET_SECRETS().vault.key : key,
+				secret: secret === undefined ? GET_SECRETS().vault.secret : secret,
 				connected_coins: connect ? GET_SECRETS().vault.connected_coins : []
 			}
 		}

--- a/plugins/vault/helpers.js
+++ b/plugins/vault/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { VAULT_ENDPOINT, API_HOST, GET_CONFIGURATION, GET_SECRETS } = require('../../constants');
+const { API_HOST, GET_CONFIGURATION, GET_SECRETS } = require('../../constants');
+const { VAULT_ENDPOINT } = require('../constants');
 const rp = require('request-promise');
 const { intersection, union, each } = require('lodash');
 const WEBHOOK_URL = (coin) => `${API_HOST}/v1/deposit/${coin}`;
@@ -151,7 +152,7 @@ const checkWebhook = (wallet, vaultConfig) => {
 			body: {
 				url: WEBHOOK_URL(wallet.currency)
 			},
-			uri: `${VAULT_ENDPOINT}/${wallet.name}/webhook`,
+			uri: `${VAULT_ENDPOINT}/wallet/${wallet.name}/webhook`,
 			json: true
 		};
 		return rp(options);

--- a/plugins/vault/index.js
+++ b/plugins/vault/index.js
@@ -70,7 +70,7 @@ app.post('/plugins/vault/connect', [verifyToken, bodyParser.json()], (req, res) 
 	);
 
 	if (!isUrl(API_HOST)) {
-		return res.status(400).json({ message: `Server URL ${API_HOST} is not a valid URL`});
+		return res.status(400).json({ message: `Server URL ${API_HOST} is not a valid URL` });
 	}
 
 	const { name, key, secret, coins } = req.body;

--- a/plugins/vault/index.js
+++ b/plugins/vault/index.js
@@ -4,6 +4,7 @@ const app = require('../index');
 const { verifyToken, checkScopes } = require('../helpers/auth');
 const bodyParser = require('body-parser');
 const { logger, isUrl, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const { updateVaultValues, crossCheckCoins, createOrUpdateWallets, cronTask } = require('./helpers');
 const { API_HOST } = require('../../constants');
 const { GET_SECRETS } = require('../../constants');
@@ -13,12 +14,16 @@ cronTask.start();
 app.get('/plugins/vault/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/vault/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/vault/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('vault', GET_SECRETS().vault) || {});
@@ -30,12 +35,16 @@ app.get('/plugins/vault/constant', verifyToken, (req, res) => {
 app.put('/plugins/vault/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/vault/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/vault/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/vault/constant error', 'Must provide key to update');
@@ -62,12 +71,16 @@ app.put('/plugins/vault/constant', [verifyToken, bodyParser.json()], (req, res) 
 app.post('/plugins/vault/connect', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'POST /plugins/vault/connect',
 		req.auth.email
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('POST /plugins/vault/connect error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (!isUrl(API_HOST)) {
 		return res.status(400).json({ message: `Server URL ${API_HOST} is not a valid URL` });
@@ -97,12 +110,16 @@ app.post('/plugins/vault/connect', [verifyToken, bodyParser.json()], (req, res) 
 app.get('/plugins/vault/disconnect', verifyToken, (req, res) => {
 	const endpointScopes = ['admin'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/vault/disconnect',
 		req.auth.email
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/vault/disconnect error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	updateVaultValues('', '', '', false)
 		.then(() => {

--- a/plugins/xht_fee/index.js
+++ b/plugins/xht_fee/index.js
@@ -4,6 +4,7 @@ const app = require('../index');
 const { verifyToken, checkScopes } = require('../helpers/auth');
 const { findUser } = require('../helpers/user');
 const { logger, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const bodyParser = require('body-parser');
 const { Balance } = require('../../db/models');
 
@@ -14,12 +15,16 @@ const { GET_SECRETS } = require('../../constants');
 app.get('/plugins/xht_fee/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/xht_fee/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/xht_fee/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('xht_fee', GET_SECRETS().plugins.xht_fee) || {});
@@ -31,12 +36,16 @@ app.get('/plugins/xht_fee/constant', verifyToken, (req, res) => {
 app.put('/plugins/xht_fee/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/xht_fee/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/xht_fee/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/xht_fee/constant error', 'Must provide key to update');
@@ -60,7 +69,16 @@ app.put('/plugins/xht_fee/constant', [verifyToken, bodyParser.json()], (req, res
 app.get('/plugins/activate-xht-fee', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['user'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
+
+	logger.verbose(
+		'GET /plugins/activate-xht-fee auth',
+		req.auth.sub
+	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/activate-xht-fee error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	const email = req.auth.sub.email;
 	const id = req.auth.sub.id;

--- a/plugins/zendesk/index.js
+++ b/plugins/zendesk/index.js
@@ -4,17 +4,22 @@ const app = require('../index');
 const { verifyToken, checkScopes } = require('../helpers/auth');
 const { GET_SECRETS } = require('../../constants');
 const { logger, updatePluginConstant, maskSecrets } = require('../helpers/common');
+const { NOT_AUTHORIZED } = require('../helpers/messages');
 const bodyParser = require('body-parser');
 
 app.get('/plugins/zendesk/constant', verifyToken, (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'GET /plugins/zendesk/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('GET /plugins/zendesk/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	try {
 		res.json(maskSecrets('zendesk', GET_SECRETS().plugins.zendesk) || {});
@@ -26,12 +31,16 @@ app.get('/plugins/zendesk/constant', verifyToken, (req, res) => {
 app.put('/plugins/zendesk/constant', [verifyToken, bodyParser.json()], (req, res) => {
 	const endpointScopes = ['admin', 'tech'];
 	const scopes = req.auth.scopes;
-	checkScopes(endpointScopes, scopes);
 
 	logger.verbose(
 		'PUT /plugins/zendesk/constant auth',
 		req.auth.sub
 	);
+
+	if (!checkScopes(endpointScopes, scopes)) {
+		logger.error('PUT /plugins/zendesk/constant error', NOT_AUTHORIZED);
+		return res.status(400).json({ message: NOT_AUTHORIZED });
+	}
 
 	if (req.body.length === 0) {
 		logger.error('PUT /plugins/zendesk/constant error', 'Must provide key to update');

--- a/web/src/config/constants.js
+++ b/web/src/config/constants.js
@@ -520,7 +520,7 @@ export const EXCHANGE_EXPIRY_DAYS = 15;
 export const EXCHANGE_EXPIRY_SECONDS = EXCHANGE_EXPIRY_DAYS * 86400;
 export const SUPPORT_HELP_URL =
 	'https://info.hollaex.com/hc/en-us/requests/new';
-export const REQUEST_VAULT_SUPPORTED_COINS = 'https://api.bitholla.com/v1/vault/coins';
+export const REQUEST_VAULT_SUPPORTED_COINS = 'https://api.vault.bitholla.com/v1/coins';
 export const ADMIN_GUIDE_DOWNLOAD_LINK = 'https://bitholla.s3.ap-northeast-2.amazonaws.com/kit/Admin+panel+manual.pdf';
 	
 export const MAX_NUMBER_BANKS = 3;


### PR DESCRIPTION
- If no values are given when connecting vault, plugin will use existing values
- Passing masked secret value will throw an error
- `checkScopes` was throwing an error if user scope was not valid instead of sending an error response, causing plugin container to restart