### PR TITLE
Plugins

### DIFF
--- a/server/api/controllers/admin.js
+++ b/server/api/controllers/admin.js
@@ -81,9 +81,6 @@ const putAdminKit = (req, res) => {
 		if (data.secrets.plugins) {
 			loggerAdmin.error(req.uuid, 'controllers/admin/putAdminKit', 'Cannot update plugins values through this endpoint');
 			return res.status(400).json({ message: 'Cannot update plugins values through this endpoint'});
-		} else if (data.secrets.exchange_credentials_set) {
-			loggerAdmin.error(req.uuid, 'controllers/admin/putAdminKit', 'Cannot update exchange_credentials_set value through this endpoint');
-			return res.status(400).json({ message: 'Cannot update exchange_credentials_set value through this endpoint'});
 		} else if (data.secrets.setup_completed) {
 			loggerAdmin.error(req.uuid, 'controllers/admin/putAdminKit', 'Cannot update setup_completed value through this endpoint');
 			return res.status(400).json({ message: 'Cannot update setup_completed value through this endpoint'});

--- a/server/api/controllers/withdrawal.js
+++ b/server/api/controllers/withdrawal.js
@@ -67,7 +67,7 @@ const performWithdrawal = (req, res) => {
 		req.swagger.params.data.value
 	);
 
-	const { token, otp_code } = req.swagger.params.data.value;
+	const { token } = req.swagger.params.data.value;
 
 	loggerWithdrawals.verbose(
 		req.uuid,
@@ -83,7 +83,7 @@ const performWithdrawal = (req, res) => {
 			if (user.verification_level < 1) {
 				throw new Error('User must upgrade verification level to perform a withdrawal');
 			}
-			return all([ toolsLib.transaction.performWithdrawal(withdrawal.user_id, withdrawal.address, withdrawal.currency, withdrawal.amount, withdrawal.fee, otp_code), withdrawal ]);
+			return all([ toolsLib.transaction.performWithdrawal(withdrawal.user_id, withdrawal.address, withdrawal.currency, withdrawal.amount, withdrawal.fee), withdrawal ]);
 		})
 		.then(([ { transaction_id }, { fee } ]) => {
 			return res.json({

--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -4224,11 +4224,6 @@ definitions:
       token:
         type: string
         description: withdrawal confirmation token
-      otp_code:
-        type: string
-        description: OTP code when otp is enabled
-        minLength: 6
-        maxLength: 6
   StatsResponse:
     type: object
     properties:

--- a/server/constants.js
+++ b/server/constants.js
@@ -119,6 +119,7 @@ subscriber.on('message', (channel, message) => {
 				updateAllConfig(data.configuration, data.secrets, data.frozenUsers);
 				break;
 			case 'update':
+				if (data.info) updateKitInfo(data.info);
 				if (data.kit) updateKit(data.kit);
 				if (data.secrets) updateSecrets(data.secrets);
 				break;
@@ -179,6 +180,10 @@ const resetAllConfig = () => {
 		}
 	};
 	setRedisData();
+};
+
+const updateKitInfo = (newInfo) => {
+	Object.assign(configuration.kit.info, newInfo);
 };
 
 const updateKit = (newKitConfig) => {

--- a/server/constants.js
+++ b/server/constants.js
@@ -403,7 +403,6 @@ exports.KIT_CONFIG_KEYS = [
 ];
 
 exports.KIT_SECRETS_KEYS = [
-	'exchange_credentials_set',
 	'setup_completed',
 	'allowed_domains',
 	'admin_whitelist',

--- a/server/db/seeders/20190825120350-add-status.js
+++ b/server/db/seeders/20190825120350-add-status.js
@@ -87,7 +87,6 @@ const status = [{
 	secrets: JSON.stringify({
 		allowed_domains: ALLOWED_DOMAINS ? ALLOWED_DOMAINS.split(',') : [],
 		admin_whitelist: ADMIN_WHITELIST_IP ? ADMIN_WHITELIST_IP.split(',') : [],
-		exchange_credentials_set: API_KEY && API_SECRET ? true : false,
 		setup_completed: false,
 		broker: {
 			quick_trade_rate: 0.03,

--- a/server/init.js
+++ b/server/init.js
@@ -85,6 +85,9 @@ const checkStatus = () => {
 			} else if (!status.activation_code) {
 				stop();
 				throw new Error('Exchange activation code is not set');
+			} else if (!status.api_key || !status.api_secret) {
+				stop();
+				throw new Error('Exchange keys are not set.');
 			} else if (!status.activated) {
 				stop();
 				throw new Error('Exchange is expired');

--- a/server/tools/dbs/checkConfig.js
+++ b/server/tools/dbs/checkConfig.js
@@ -58,9 +58,6 @@ Status.findOne()
 		const secrets = {
 			allowed_domains: existingSecrets.allowed_domains || (process.env.ALLOWED_DOMAINS ? process.env.ALLOWED_DOMAINS.split(',') : []),
 			admin_whitelist: existingSecrets.admin_whitelist || (process.env.ADMIN_WHITELIST_IP ? process.env.ADMIN_WHITELIST_IP.split(',') : []),
-			exchange_credentials_set: isBoolean(existingSecrets.exchange_credentials_set)
-				? existingSecrets.exchange_credentials_set
-				: ( status.dataValues.api_key && status.dataValues.api_secret ? true : false ),
 			setup_completed: isBoolean(existingSecrets.setup_completed) ? existingSecrets.setup_completed : false,
 			broker: {
 				quick_trade_rate: existingSecrets.broker.quick_trade_rate || 0.03,

--- a/server/tools/dbs/setConfig.js
+++ b/server/tools/dbs/setConfig.js
@@ -89,7 +89,6 @@ const kit = {
 const secrets = {
 	allowed_domains: ALLOWED_DOMAINS ? ALLOWED_DOMAINS.split(',') : [],
 	admin_whitelist: ADMIN_WHITELIST_IP ? ADMIN_WHITELIST_IP.split(',') : [],
-	exchange_credentials_set: API_KEY && API_SECRET ? true : false,
 	setup_completed: false,
 	broker: {
 		quick_trade_rate: 0.03,


### PR DESCRIPTION
- Remove `otp_code` from /complete-withdrawal
- Remove `exchange_credentials_set`
- Required `api_key` and `api_secret` to be stored before exchange runs
- Update `info.initialized` after first admin creation

Tools Changes
- Remove `otp_code` from performWithdrawal
- Publish `initialized` and `setup_complete` when they are set to `true` during initial exchange setup wizard
- Remove `exchange_credentials_set` update after `api_key` and `api_secret` updates
- createUser (used during initial admin creation) updates `Verification Code.verified` to true after admin creation
