### PR TITLE
websocket  exchange id set dynamically and trades => trade

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -15,8 +15,8 @@ exports.WEBSOCKET_CHANNEL = (topic, symbolOrUserId) => {
 	switch(topic) {
 		case 'orderbook':
 			return `orderbook:${symbolOrUserId}`;
-		case 'trades':
-			return `trades:${symbolOrUserId}`;
+		case 'trade':
+			return `trade:${symbolOrUserId}`;
 		case 'order':
 			return `order:${symbolOrUserId}`;
 		case 'wallet':

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -6,18 +6,35 @@ const toolsLib = require('hollaex-tools-lib');
 const { handleHubData } = require('./sub');
 const { setWsHeartbeat } = require('ws-heartbeat/client');
 const { loggerWebsocket } = require('../config/logger');
+const { all } = require('bluebird');
+const rp = require('request-promise');
+
+const HE_NETWORK_ENDPOINT = 'https://api.testnet.hollaex.network';
+const HE_NETWORK_BASE_URL = '/v2';
+const PATH_ACTIVATE = '/exchange/activate';
+const HE_NETWORK_WS_ENDPOINT = 'wss://api.testnet.hollaex.network/stream';
 
 const apiExpires = moment().toISOString() + 60;
 let ws;
 
 const connect = () => {
 	toolsLib.database.findOne('status', { raw: true })
-		.then(({ api_key, api_secret }) => {
-			const signature = toolsLib.auth.createHmacSignature(api_secret, 'CONNECT', '/stream', apiExpires);
-
-			ws = new WebSocket('wss://api.testnet.hollaex.network/stream?exchange_id=106', {
+		.then((status) => {
+			return all([
+				checkActivation(
+					status.name,
+					status.url,
+					status.activation_code,
+					status.constants
+				),
+				status
+			]);
+		})
+		.then(([ exchange, status ]) => {
+			const signature = toolsLib.auth.createHmacSignature(status.api_secret, 'CONNECT', '/stream', apiExpires);
+			ws = new WebSocket(`${HE_NETWORK_WS_ENDPOINT}?exchange_id=${exchange.id}`, {
 				headers : {
-					'api-key': api_key,
+					'api-key': status.api_key,
 					'api-signature': signature,
 					'api-expires': apiExpires
 				}
@@ -60,6 +77,21 @@ const sendNetworkWsMessage = (op, topic, networkId) => {
 	if (ws) {
 		ws.send(JSON.stringify({ op, args: [`${topic}:${networkId}`] }));
 	}
+};
+
+const checkActivation = (name, url, activation_code, constants = {}) => {
+	const options = {
+		method: 'POST',
+		body: {
+			name,
+			url,
+			activation_code,
+			constants
+		},
+		uri: `${HE_NETWORK_ENDPOINT}${HE_NETWORK_BASE_URL}${PATH_ACTIVATE}`,
+		json: true
+	};
+	return rp(options);
 };
 
 module.exports = {

--- a/server/ws/sub.js
+++ b/server/ws/sub.js
@@ -16,24 +16,28 @@ const {
 
 let publicData = {
 	orderbook: {},
-	trades: {}
+	trade: {}
 };
 
 const initializeTopic = (topic, ws, symbol) => {
 	switch (topic) {
 		case 'orderbook':
-		case 'trades':
+		case 'trade':
 			if (symbol) {
 				if (!toolsLib.subscribedToPair(symbol)) {
 					throw new Error('Invalid symbol');
 				}
 				addSubscriber(WEBSOCKET_CHANNEL(topic, symbol), ws);
-				ws.send(JSON.stringify(publicData[topic][symbol]));
+				if (publicData[topic][symbol]) {
+					ws.send(JSON.stringify(publicData[topic][symbol]));
+				}
 			} else {
 				each(toolsLib.getKitPairs(), (pair) => {
 					try {
 						addSubscriber(WEBSOCKET_CHANNEL(topic, pair), ws);
-						ws.send(JSON.stringify(publicData[topic][pair]));
+						if (publicData[topic][pair]) {
+							ws.send(JSON.stringify(publicData[topic][pair]));
+						}
 					} catch (err) {
 						ws.send(JSON.stringify({ message: err.message }));
 					}
@@ -61,7 +65,7 @@ const initializeTopic = (topic, ws, symbol) => {
 const terminateTopic = (topic, ws, symbol) => {
 	switch (topic) {
 		case 'orderbook':
-		case 'trades':
+		case 'trade':
 			if (symbol) {
 				if (!toolsLib.subscribedToPair(symbol)) {
 					throw new Error('Invalid symbol');
@@ -144,7 +148,7 @@ const terminateClosedChannels = (ws) => {
 			loggerWebsocket.debug('ws/sub/terminateClosedChannels', err.message);
 		}
 		try {
-			removeSubscriber(WEBSOCKET_CHANNEL('trades', pair), ws);
+			removeSubscriber(WEBSOCKET_CHANNEL('trade', pair), ws);
 		} catch (err) {
 			loggerWebsocket.debug('ws/sub/terminateClosedChannels', err.message);
 		}
@@ -188,7 +192,7 @@ const handleHubData = (data) => {
 				ws.send(JSON.stringify(data));
 			});
 			break;
-		case 'trades':
+		case 'trade':
 			if (data.action === 'partial') {
 				publicData[data.topic][data.symbol] = data;
 			} else {


### PR DESCRIPTION
- Previously, network websocket url was hardcoded to `wss://testnet.hollaex.network/stream?exchange_id=106`
    - Now, websocket network url `exchange_id` is set dynamically using `checkActivation` from `init.js`
- Add check before sending data to client, if data is undefined, don't send anything
- Change event `trades` to `trade`