### PR TITLE
Websocket

### DIFF
--- a/server/init.js
+++ b/server/init.js
@@ -24,7 +24,7 @@ subscriber.on('message', (channel, message) => {
 		const { type } = JSON.parse(message);
 		switch(type) {
 			case 'refreshInit':
-				checkStatus();
+				checkStatus(true);
 				break;
 			default:
 				break;
@@ -35,7 +35,7 @@ subscriber.on('message', (channel, message) => {
 
 subscriber.subscribe(INIT_CHANNEL);
 
-const checkStatus = () => {
+const checkStatus = (restart = false) => {
 	loggerGeneral.verbose('init/checkStatus', 'checking exchange status');
 
 	let configuration = {
@@ -151,6 +151,9 @@ const checkStatus = () => {
 			);
 		})
 		.then(() => {
+			if (restart) {
+				require('./ws/hub').ws.close();
+			}
 			loggerGeneral.info('init/checkStatus/activation complete');
 		})
 		.catch((err) => {

--- a/server/init.js
+++ b/server/init.js
@@ -152,7 +152,10 @@ const checkStatus = (restart = false) => {
 		})
 		.then(() => {
 			if (restart) {
-				require('./ws/hub').getWs().close();
+				const { getWs, hubConnected } = require('./ws/hub');
+				if (hubConnected()) {
+					getWs().close();
+				}
 			}
 			loggerGeneral.info('init/checkStatus/activation complete');
 		})

--- a/server/init.js
+++ b/server/init.js
@@ -152,7 +152,7 @@ const checkStatus = (restart = false) => {
 		})
 		.then(() => {
 			if (restart) {
-				require('./ws/hub').ws.close();
+				require('./ws/hub').getWs().close();
 			}
 			loggerGeneral.info('init/checkStatus/activation complete');
 		})

--- a/server/ws/channel.js
+++ b/server/ws/channel.js
@@ -42,8 +42,13 @@ const removeSubscriber = (channel, ws, type = undefined) => {
 	}
 };
 
+const resetChannels = () => {
+	channels = {};
+};
+
 module.exports = {
 	getChannels,
 	addSubscriber,
-	removeSubscriber
+	removeSubscriber,
+	resetChannels
 };

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -51,6 +51,7 @@ const connect = () => {
 
 			ws.on('error', (err) => {
 				loggerWebsocket.error('ws/hub err', err.message);
+				ws.close();
 			});
 
 			ws.on('close', () => {

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -14,10 +14,12 @@ const HE_NETWORK_BASE_URL = '/v2';
 const PATH_ACTIVATE = '/exchange/activate';
 const HE_NETWORK_WS_ENDPOINT = 'wss://api.testnet.hollaex.network/stream';
 
-let hubConnected = false;
+let connected = false;
+const hubConnected = () => connected;
 
 const apiExpires = moment().toISOString() + 60;
 let ws;
+const getWs = () => ws;
 
 const reconnectInterval = 5000; // 5 seconds
 
@@ -45,7 +47,7 @@ const connect = () => {
 			});
 
 			ws.on('open', () => {
-				hubConnected = true;
+				connected = true;
 				ws.send(JSON.stringify({
 					op: 'subscribe',
 					args: ['orderbook', 'trade']
@@ -59,7 +61,7 @@ const connect = () => {
 
 			ws.on('close', () => {
 				loggerWebsocket.info('ws/hub close', ws.id);
-				hubConnected = false;
+				connected = false;
 				closeAllClients();
 				setTimeout(connect, reconnectInterval);
 			});
@@ -107,5 +109,5 @@ module.exports = {
 	sendNetworkWsMessage,
 	connect,
 	hubConnected,
-	ws
+	getWs
 };

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -106,5 +106,6 @@ const checkActivation = (name, url, activation_code, constants = {}) => {
 module.exports = {
 	sendNetworkWsMessage,
 	connect,
-	hubConnected
+	hubConnected,
+	ws
 };

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -14,6 +14,8 @@ const HE_NETWORK_BASE_URL = '/v2';
 const PATH_ACTIVATE = '/exchange/activate';
 const HE_NETWORK_WS_ENDPOINT = 'wss://api.testnet.hollaex.network/stream';
 
+let hubConnected = false;
+
 const apiExpires = moment().toISOString() + 60;
 let ws;
 
@@ -43,6 +45,7 @@ const connect = () => {
 			});
 
 			ws.on('open', () => {
+				hubConnected = true;
 				ws.send(JSON.stringify({
 					op: 'subscribe',
 					args: ['orderbook', 'trade']
@@ -56,6 +59,7 @@ const connect = () => {
 
 			ws.on('close', () => {
 				loggerWebsocket.info('ws/hub close', ws.id);
+				hubConnected = false;
 				closeAllClients();
 				setTimeout(connect, reconnectInterval);
 			});
@@ -101,5 +105,6 @@ const checkActivation = (name, url, activation_code, constants = {}) => {
 
 module.exports = {
 	sendNetworkWsMessage,
-	connect
+	connect,
+	hubConnected
 };

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -47,6 +47,7 @@ const connect = () => {
 			});
 
 			ws.on('open', () => {
+				loggerWebsocket.info('ws/hub open');
 				connected = true;
 				ws.send(JSON.stringify({
 					op: 'subscribe',

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -17,6 +17,8 @@ const HE_NETWORK_WS_ENDPOINT = 'wss://api.testnet.hollaex.network/stream';
 const apiExpires = moment().toISOString() + 60;
 let ws;
 
+const reconnectInterval = 5000; // 5 seconds
+
 const connect = () => {
 	toolsLib.database.findOne('status', { raw: true })
 		.then((status) => {
@@ -53,6 +55,7 @@ const connect = () => {
 
 			ws.on('close', () => {
 				loggerWebsocket.info('ws/hub close', ws.id);
+				setTimeout(connect, reconnectInterval);
 			});
 
 			ws.on('message', (data) => {

--- a/server/ws/hub.js
+++ b/server/ws/hub.js
@@ -3,7 +3,7 @@
 const WebSocket = require('ws');
 const moment = require('moment');
 const toolsLib = require('hollaex-tools-lib');
-const { handleHubData } = require('./sub');
+const { handleHubData, closeAllClients } = require('./sub');
 const { setWsHeartbeat } = require('ws-heartbeat/client');
 const { loggerWebsocket } = require('../config/logger');
 const { all } = require('bluebird');
@@ -56,6 +56,7 @@ const connect = () => {
 
 			ws.on('close', () => {
 				loggerWebsocket.info('ws/hub close', ws.id);
+				closeAllClients();
 				setTimeout(connect, reconnectInterval);
 			});
 

--- a/server/ws/index.js
+++ b/server/ws/index.js
@@ -11,7 +11,7 @@ const {
 	WS_USER_AUTHENTICATED
 } = require('../messages');
 const { initializeTopic, terminateTopic, authorizeUser, terminateClosedChannels } = require('./sub');
-const { connect } = require('./hub');
+const { connect, hubConnected } = require('./hub');
 const { setWsHeartbeat } = require('ws-heartbeat/server');
 
 wss.on('connection', (ws, req) => {
@@ -69,7 +69,9 @@ wss.on('connection', (ws, req) => {
 	});
 
 	ws.on('close', () => {
-		terminateClosedChannels(ws);
+		if (hubConnected) {
+			terminateClosedChannels(ws);
+		}
 	});
 });
 

--- a/server/ws/index.js
+++ b/server/ws/index.js
@@ -12,6 +12,7 @@ const {
 } = require('../messages');
 const { initializeTopic, terminateTopic, authorizeUser, terminateClosedChannels } = require('./sub');
 const { connect, hubConnected } = require('./hub');
+const { getChannels } = require('./channel');
 const { setWsHeartbeat } = require('ws-heartbeat/server');
 
 wss.on('connection', (ws, req) => {
@@ -69,7 +70,7 @@ wss.on('connection', (ws, req) => {
 	});
 
 	ws.on('close', () => {
-		if (hubConnected) {
+		if (hubConnected()) {
 			terminateClosedChannels(ws);
 		}
 	});

--- a/server/ws/server.js
+++ b/server/ws/server.js
@@ -52,6 +52,12 @@ const wss = new WebSocket.Server({
 	port: PORT,
 	verifyClient: (info, next) => {
 		try {
+			const hubConnected = require('./hub');
+
+			if (!hubConnected) {
+				throw new Error('Hub websocket is disconnected');
+			}
+
 			const query = url.parse(info.req.url, true).query;
 			const bearerToken = query.authorization;
 			const hmacKey = query['api-key'];
@@ -91,8 +97,8 @@ const wss = new WebSocket.Server({
 				return next(true);
 			}
 		} catch (err) {
-			loggerWebsocket.error('ws/server/catch', err);
-			return next(false, 400, 'Wrong format. Follow /stream?exchange_id=<exchangeId> format');
+			loggerWebsocket.error('ws/server/catch', err.message);
+			return next(false, 400, err.message);
 		}
 	}
 });

--- a/server/ws/server.js
+++ b/server/ws/server.js
@@ -52,9 +52,9 @@ const wss = new WebSocket.Server({
 	port: PORT,
 	verifyClient: (info, next) => {
 		try {
-			const hubConnected = require('./hub');
+			const { hubConnected } = require('./hub');
 
-			if (!hubConnected) {
+			if (!hubConnected()) {
 				throw new Error('Hub websocket is disconnected');
 			}
 

--- a/server/ws/server.js
+++ b/server/ws/server.js
@@ -74,7 +74,7 @@ const wss = new WebSocket.Server({
 			} else if (hmacKey) {
 				info.req.headers['api-key'] = hmacKey;
 				info.req.headers['api-signature'] = query['api-signature'];
-				info.req.headers['api-expires'] = parseInt(query['api-expires']);
+				info.req.headers['api-expires'] = query['api-expires'];
 				info.req.method = 'CONNECT';
 				info.req.originalUrl = '/stream';
 				// Function will set req.auth to authenticated token object if successful

--- a/server/ws/sub.js
+++ b/server/ws/sub.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addSubscriber, removeSubscriber, getChannels } = require('./channel');
+const { addSubscriber, removeSubscriber, getChannels, resetChannels } = require('./channel');
 const { WEBSOCKET_CHANNEL } = require('../constants');
 const { each } = require('lodash');
 const toolsLib = require('hollaex-tools-lib');
@@ -215,10 +215,20 @@ const handleHubData = (data) => {
 	}
 };
 
+const closeAllClients = () => {
+	each(getChannels(), (channel) => {
+		each(channel, (ws) => {
+			ws.close();
+		});
+	});
+	resetChannels();
+};
+
 module.exports = {
 	initializeTopic,
 	terminateTopic,
 	handleHubData,
 	authorizeUser,
-	terminateClosedChannels
+	terminateClosedChannels,
+	closeAllClients
 };

--- a/server/ws/sub.js
+++ b/server/ws/sub.js
@@ -222,6 +222,10 @@ const closeAllClients = () => {
 		});
 	});
 	resetChannels();
+	publicData = {
+		orderbook: {},
+		trade: {}
+	};
 };
 
 module.exports = {


### PR DESCRIPTION
- Automatic reconnection to network websocket
    - based on this [stack overflow answer](https://stackoverflow.com/a/26194961)
- Initial connection authorization moved from headers to query
- When kit ws disconnects from network, close all client connections and reset channels and publicData(ob, trade data)
- Close kit => hub websocket connect when new changes applied
- Add flag for hubConnected
    - Client connection will fail if hubConnected is false