### PR TITLE
remove /admin/upload bearer token requirement

### DIFF
--- a/server/api/controllers/admin.js
+++ b/server/api/controllers/admin.js
@@ -494,6 +494,11 @@ const uploadImage = (req, res) => {
 	const givenApiKey = req.headers['api-key'];
 
 	if (!givenApiKey) {
+		loggerAdmin.error(
+			req.uuid,
+			'controllers/admin/uploadImage',
+			'Missing headers'
+		);
 		return res.status(401).json({ message: 'Missing headers' });
 	}
 

--- a/server/api/controllers/admin.js
+++ b/server/api/controllers/admin.js
@@ -491,10 +491,22 @@ const uploadImage = (req, res) => {
 		req.auth
 	);
 
+	const givenApiKey = req.headers['api-key'];
+
+	if (!givenApiKey) {
+		return res.status(401).json({ message: 'Missing headers' });
+	}
+
 	const name = req.swagger.params.name.value;
 	const file = req.swagger.params.file.value;
 
-	toolsLib.image.storeImageOnNetwork(file, name)
+	toolsLib.getNetworkKeySecret()
+		.then(({ apiKey }) => {
+			if (givenApiKey !== apiKey) {
+				throw new Error('Not authorized');
+			}
+			return toolsLib.image.storeImageOnNetwork(file, name);
+		})
 		.then((result) => {
 			return res.json(result);
 		})

--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -1723,10 +1723,6 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/MessageResponse"
-      security:
-        - Bearer: []
-      x-security-scopes:
-        - admin
   /admin/pairs:
     x-swagger-router-controller: admin
     get:


### PR DESCRIPTION
- Remove bearer requirement for admin/upload and check api-key given

Uploading image logic is working on the sandbox server, just had to fix the authorization logic behind it
It requires `api-key` to be passed in the headers