### PR TITLE
fix for getting trade, order, balance

### DIFF
--- a/server/api/controllers/order.js
+++ b/server/api/controllers/order.js
@@ -125,8 +125,8 @@ const cancelAllUserOrders = (req, res) => {
 		});
 };
 
-const getAdminUserOrders = (req, res) => {
-	loggerOrders.verbose(req.uuid, 'controllers/order/getAdminUserOrders/auth', req.auth);
+const getAdminOrders = (req, res) => {
+	loggerOrders.verbose(req.uuid, 'controllers/order/getAdminOrders/auth', req.auth);
 	const { user_id, symbol, side, status, open, limit, page, order_by, order, start_date, end_date } = req.swagger.params;
 
 	let promiseQuery;
@@ -165,7 +165,7 @@ const getAdminUserOrders = (req, res) => {
 			return res.json(orders);
 		})
 		.catch((err) => {
-			loggerOrders.debug(req.uuid, 'controllers/order/getAdminUserOrder', err.message);
+			loggerOrders.debug(req.uuid, 'controllers/order/getAdminOrders', err.message);
 			return res.status(err.status || 400).json({ message: err.message });
 		});
 };
@@ -196,6 +196,6 @@ module.exports = {
 	cancelUserOrder,
 	getAllUserOrders,
 	cancelAllUserOrders,
-	getAdminUserOrders,
+	getAdminOrders,
 	adminCancelOrder
 };

--- a/server/api/controllers/order.js
+++ b/server/api/controllers/order.js
@@ -17,7 +17,7 @@ const createOrder = (req, res) => {
 	);
 
 	const user_id = req.auth.sub.id;
-	const order = req.swagger.params.order.value;
+	let order = req.swagger.params.order.value;
 
 	const opts = {};
 
@@ -27,6 +27,10 @@ const createOrder = (req, res) => {
 
 	if (isNumber(order.stop)) {
 		opts.stop = order.stop;
+	}
+
+	if (order.type === 'market') {
+		delete order.price;
 	}
 
 	toolsLib.order.createUserOrderByKitId(user_id, order.symbol, order.side, order.size, order.type, order.price, opts)

--- a/server/api/controllers/trade.js
+++ b/server/api/controllers/trade.js
@@ -35,8 +35,8 @@ const getUserTrades = (req, res) => {
 		});
 };
 
-const getAdminUserTrades = (req, res) => {
-	loggerTrades.verbose(req.uuid, 'controllers/trade/getAdminUserTrades auth', req.auth);
+const getAdminTrades = (req, res) => {
+	loggerTrades.verbose(req.uuid, 'controllers/trade/getAdminTrades auth', req.auth);
 
 	const { user_id, symbol, limit, page, order_by, order, start_date, end_date, format } = req.swagger.params;
 
@@ -59,12 +59,12 @@ const getAdminUserTrades = (req, res) => {
 			}
 		})
 		.catch((err) => {
-			loggerTrades.error(req.uuid, 'controllers/trade/getAdminUserTrades', err.message);
+			loggerTrades.error(req.uuid, 'controllers/trade/getAdminTrades', err.message);
 			return res.status(err.status || 400).json({ message: err.message });
 		});
 };
 
 module.exports = {
 	getUserTrades,
-	getAdminUserTrades
+	getAdminTrades
 };

--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -2556,7 +2556,7 @@ paths:
     x-swagger-router-controller: order
     get:
       description: Get user orders for admin
-      operationId: getAdminUserOrders
+      operationId: getAdminOrders
       parameters:
         - in: query
           name: user_id
@@ -2672,7 +2672,7 @@ paths:
     x-swagger-router-controller: trade
     get:
       description: Get user trades for admin
-      operationId: getAdminUserTrades
+      operationId: getAdminTrades
       parameters:
         - in: query
           name: user_id

--- a/server/messages.js
+++ b/server/messages.js
@@ -5,6 +5,7 @@ exports.INSUFFICIENT_BALANCE_ORDER =
 exports.MISSING_ORDER = 'Missing order';
 exports.INVALID_USER_ID = 'Invalid user.';
 exports.USER_NOT_FOUND = 'User not found';
+exports.USER_NOT_REGISTERED_ON_NETWORK = 'User is not registered on the network';
 exports.SIGNUP_NOT_AVAILABLE = 'Sign up not available';
 exports.USER_NOT_VERIFIED = 'User is not verified';
 exports.USER_NOT_ACTIVATED = 'User is not activated';


### PR DESCRIPTION
- getTrade
- getOrder
- getBalance
- getDeposit
- getWithdrawal

fixed to check for `user_id` before getting data for a specific user. Will throw an error if user hasn't been registered on network. 