### PR TITLE
Plugins

### DIFF
--- a/server/db/migrations/20210331025558-change-script-plugins.js
+++ b/server/db/migrations/20210331025558-change-script-plugins.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const TABLE = 'Plugins';
+const COLUMN = 'script';
+
+module.exports = {
+	up: (queryInterface, Sequelize) =>
+		queryInterface.changeColumn(TABLE, COLUMN, {
+			type: Sequelize.TEXT,
+			allowNull: true
+		}),
+	down: (queryInterface, Sequelize) =>
+		queryInterface.changeColumn(TABLE, COLUMN, {
+			type: Sequelize.TEXT,
+			allowNull: false
+		})
+};

--- a/server/db/models/plugin.js
+++ b/server/db/models/plugin.js
@@ -53,7 +53,7 @@ module.exports = (sequelize, DataTypes) => {
 		},
 		script: {
 			type: DataTypes.TEXT,
-			allowNull: false
+			allowNull: true
 		},
 		admin_view: {
 			type: DataTypes.TEXT


### PR DESCRIPTION
- Added migration to allow `plugins.script` to be null
- Plugin model file update for script change
- Endpoint updates to allow script to be null
- Plugins restarted only when plugin is `enabled` and has a `script`
- Plugin `exec` only ran for plugins that are `enabled` and have a `script`