### PR TITLE
Kit update

### DIFF
--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -3832,7 +3832,7 @@ definitions:
             type: boolean
           native_currency:
             type: string
-          injected_value:
+          injected_values:
             type: array
             items:
               type: object

--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -3832,6 +3832,21 @@ definitions:
             type: boolean
           native_currency:
             type: string
+          injected_value:
+            type: array
+            items:
+              type: object
+              required:
+                - tag
+                - target
+                - attributes
+              properties:
+                tag:
+                  type: string
+                target:
+                  type: string
+                attributes:
+                  type: object
       secrets:
         type: object
         properties:

--- a/server/constants.js
+++ b/server/constants.js
@@ -151,7 +151,7 @@ exports.KIT_CONFIG_KEYS = [
 	'features',
 	'setup_completed',
 	'email_verification_required',
-	'injected_value'
+	'injected_values'
 ];
 
 exports.KIT_SECRETS_KEYS = [

--- a/server/constants.js
+++ b/server/constants.js
@@ -23,7 +23,8 @@ let configuration = {
 		captcha: {},
 		defaults: {},
 		features: {},
-		meta: {}
+		meta: {},
+		injected_values: []
 	}
 };
 
@@ -96,7 +97,8 @@ const resetAllConfig = () => {
 			captcha: {},
 			defaults: {},
 			features: {},
-			meta: {}
+			meta: {},
+			injected_values: []
 		}
 	};
 };

--- a/server/constants.js
+++ b/server/constants.js
@@ -150,7 +150,8 @@ exports.KIT_CONFIG_KEYS = [
 	'meta',
 	'features',
 	'setup_completed',
-	'email_verification_required'
+	'email_verification_required',
+	'injected_value'
 ];
 
 exports.KIT_SECRETS_KEYS = [

--- a/server/db/seeders/20190825120350-add-status.js
+++ b/server/db/seeders/20190825120350-add-status.js
@@ -84,6 +84,7 @@ module.exports = {
 						logo_image: LOGO_IMAGE || 'https://dash.testnet.bitholla.com/assets/img/hex-pattern-icon-black-01.svg',
 						valid_languages: VALID_LANGUAGES || 'en,fa,ko,ar,fr',
 						new_user_is_activated: (NEW_USER_IS_ACTIVATED && NEW_USER_IS_ACTIVATED === 'true') || false,
+						injected_value: [],
 						captcha: {
 							site_key: CAPTCHA_SITE_KEY
 						},

--- a/server/db/seeders/20190825120350-add-status.js
+++ b/server/db/seeders/20190825120350-add-status.js
@@ -84,7 +84,7 @@ module.exports = {
 						logo_image: LOGO_IMAGE || 'https://dash.testnet.bitholla.com/assets/img/hex-pattern-icon-black-01.svg',
 						valid_languages: VALID_LANGUAGES || 'en,fa,ko,ar,fr',
 						new_user_is_activated: (NEW_USER_IS_ACTIVATED && NEW_USER_IS_ACTIVATED === 'true') || false,
-						injected_value: [],
+						injected_values: [],
 						captcha: {
 							site_key: CAPTCHA_SITE_KEY
 						},

--- a/server/init.js
+++ b/server/init.js
@@ -59,7 +59,8 @@ const checkStatus = () => {
 			captcha: {},
 			defaults: {},
 			features: {},
-			meta: {}
+			meta: {},
+			injected_values: []
 		}
 	};
 

--- a/server/tools/dbs/checkConfig.js
+++ b/server/tools/dbs/checkConfig.js
@@ -37,6 +37,7 @@ Status.findOne()
 			setup_completed: isBoolean(existingKitConfigurations.setup_completed) ? existingKitConfigurations.setup_completed : false,
 			native_currency: existingKitConfigurations.native_currency || process.env.NATIVE_CURRENCY || 'usdt',
 			logo_image: existingKitConfigurations.logo_image || existingKitConfigurations.logo_path || process.env.LOGO_IMAGE || 'https://dash.testnet.bitholla.com/assets/img/hex-pattern-icon-black-01.svg',
+			injected_value: existingKitConfigurations.injected_value || [],
 			valid_languages: existingKitConfigurations.valid_languages || process.env.VALID_LANGUAGES || 'en,fa,ko,ar,fr',
 			new_user_is_activated: existingKitConfigurations.new_user_is_activated || (process.env.NEW_USER_IS_ACTIVATED && process.env.NEW_USER_IS_ACTIVATED === 'true') || false,
 			captcha: {

--- a/server/tools/dbs/checkConfig.js
+++ b/server/tools/dbs/checkConfig.js
@@ -37,7 +37,7 @@ Status.findOne()
 			setup_completed: isBoolean(existingKitConfigurations.setup_completed) ? existingKitConfigurations.setup_completed : false,
 			native_currency: existingKitConfigurations.native_currency || process.env.NATIVE_CURRENCY || 'usdt',
 			logo_image: existingKitConfigurations.logo_image || existingKitConfigurations.logo_path || process.env.LOGO_IMAGE || 'https://dash.testnet.bitholla.com/assets/img/hex-pattern-icon-black-01.svg',
-			injected_value: existingKitConfigurations.injected_value || [],
+			injected_values: existingKitConfigurations.injected_values || [],
 			valid_languages: existingKitConfigurations.valid_languages || process.env.VALID_LANGUAGES || 'en,fa,ko,ar,fr',
 			new_user_is_activated: existingKitConfigurations.new_user_is_activated || (process.env.NEW_USER_IS_ACTIVATED && process.env.NEW_USER_IS_ACTIVATED === 'true') || false,
 			captcha: {

--- a/server/tools/dbs/setConfig.js
+++ b/server/tools/dbs/setConfig.js
@@ -53,7 +53,7 @@ const kit = {
 	setup_completed: false,
 	native_currency: NATIVE_CURRENCY || 'usdt',
 	logo_image: LOGO_IMAGE || 'https://dash.testnet.bitholla.com/assets/img/hex-pattern-icon-black-01.svg',
-	injected_value: [],
+	injected_values: [],
 	valid_languages: VALID_LANGUAGES || 'en,fa,ko,ar,fr',
 	new_user_is_activated: (NEW_USER_IS_ACTIVATED && NEW_USER_IS_ACTIVATED === 'true') || false,
 	captcha: {

--- a/server/tools/dbs/setConfig.js
+++ b/server/tools/dbs/setConfig.js
@@ -53,6 +53,7 @@ const kit = {
 	setup_completed: false,
 	native_currency: NATIVE_CURRENCY || 'usdt',
 	logo_image: LOGO_IMAGE || 'https://dash.testnet.bitholla.com/assets/img/hex-pattern-icon-black-01.svg',
+	injected_value: [],
 	valid_languages: VALID_LANGUAGES || 'en,fa,ko,ar,fr',
 	new_user_is_activated: (NEW_USER_IS_ACTIVATED && NEW_USER_IS_ACTIVATED === 'true') || false,
 	captcha: {


### PR DESCRIPTION
add `injected_values` to `/v2/kit` object
- `PUT /kit` overrides existing `injected_values` if it is given
- Swagger validation. Requires `injected_values` to be an array of objects with values `tag:string`, `target:string`, and `attributes:object`