### PR TITLE
email option added to mint/burn

### DIFF
--- a/server/api/controllers/admin.js
+++ b/server/api/controllers/admin.js
@@ -676,7 +676,8 @@ const mintAsset = (req, res) => {
 		amount,
 		description,
 		transaction_id,
-		status
+		status,
+		email
 	} = req.swagger.params.data.value;
 
 	loggerAdmin.info(
@@ -705,7 +706,8 @@ const mintAsset = (req, res) => {
 				{
 					description,
 					transactionId: transaction_id,
-					status
+					status,
+					email
 				}
 			);
 		})
@@ -738,7 +740,8 @@ const putMint = (req, res) => {
 		updated_transaction_id,
 		status,
 		rejected,
-		dismissed
+		dismissed,
+		email
 	} = req.swagger.params.data.value;
 
 	loggerAdmin.info(
@@ -759,7 +762,8 @@ const putMint = (req, res) => {
 		status,
 		dismissed,
 		rejected,
-		updatedTransactionId: updated_transaction_id
+		updatedTransactionId: updated_transaction_id,
+		email
 	})
 		.then((data) => {
 			loggerAdmin.info(
@@ -791,7 +795,8 @@ const burnAsset = (req, res) => {
 		amount,
 		description,
 		transaction_id,
-		status
+		status,
+		email
 	} = req.swagger.params.data.value;
 
 	loggerAdmin.info(
@@ -820,7 +825,8 @@ const burnAsset = (req, res) => {
 				{
 					description,
 					transactionId: transaction_id,
-					status
+					status,
+					email
 				}
 			);
 		})
@@ -853,7 +859,8 @@ const putBurn = (req, res) => {
 		updated_transaction_id,
 		status,
 		rejected,
-		dismissed
+		dismissed,
+		email
 	} = req.swagger.params.data.value;
 
 	loggerAdmin.info(
@@ -874,7 +881,8 @@ const putBurn = (req, res) => {
 		status,
 		dismissed,
 		rejected,
-		updatedTransactionId: updated_transaction_id
+		updatedTransactionId: updated_transaction_id,
+		email
 	})
 		.then((data) => {
 			loggerAdmin.info(

--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -4492,6 +4492,8 @@ definitions:
         type: string
       status:
         type: boolean
+      email:
+        type: boolean
   MintBurnUpdate:
     type: object
     required:
@@ -4506,4 +4508,6 @@ definitions:
       rejected:
         type: boolean
       dismissed:
+        type: boolean
+      email:
         type: boolean


### PR DESCRIPTION
- Added `email` parameter to `POST, PUT /mint, /burn`