### PR TITLE
allow communicator to upload images, edit links, injected_html, interface

### DIFF
--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -2171,6 +2171,7 @@ paths:
         - Bearer: []
       x-security-scopes:
         - admin
+        - communicator
   /admin/pairs:
     x-swagger-router-controller: admin
     get:

--- a/server/constants.js
+++ b/server/constants.js
@@ -179,6 +179,9 @@ exports.COMMUNICATOR_AUTHORIZED_KIT_CONFIG = [
 	'meta',
 	'description',
 	'title',
+	'interface',
+	'links',
+	'injected_html',
 	'features'
 ];
 // CONFIGURATION CONSTANTS END --------------------------------------------------


### PR DESCRIPTION
- Add `communicator` to allowed roles for `/upload` on swagger
- Allow `communicator` to update kit `interface`, `links`, `injected_html`