### PR TITLE
Adding minor changes

### DIFF
--- a/web/src/actions/orderAction.js
+++ b/web/src/actions/orderAction.js
@@ -55,7 +55,7 @@ export const cancelOrder = (orderId, settings) => (dispatch) => {
 
 export const cancelAllOrders = (symbol = '', settings) => (dispatch) => {
 	axios
-		.delete(`/order/all?symbol=${symbol}`)
+		.delete(`/order/all`) //?symbol=${symbol} can be used to cancel all based on pairs
 		.then((data) => {
 			dispatch({
 				type: 'CANCEL_ALL_ORDERS',

--- a/web/src/actions/orderAction.js
+++ b/web/src/actions/orderAction.js
@@ -55,7 +55,7 @@ export const cancelOrder = (orderId, settings) => (dispatch) => {
 
 export const cancelAllOrders = (symbol = '', settings) => (dispatch) => {
 	axios
-		.delete(`/order/all`) //?symbol=${symbol} can be used to cancel all based on pairs
+		.delete('/order/all') //?symbol=${symbol} can be used to cancel all based on pairs
 		.then((data) => {
 			dispatch({
 				type: 'CANCEL_ALL_ORDERS',

--- a/web/src/config/lang/ar.js
+++ b/web/src/config/lang/ar.js
@@ -1376,7 +1376,7 @@ const nestedContent = {
 	CANCEL_ORDERS: {
 		HEADING: 'Cancel orders',
 		SUB_HEADING: 'Cancel all orders',
-		INFO_1: 'This will cancel your open orders for this markets.',
+		INFO_1: 'This will cancel your open orders for all markets.',
 		INFO_2: 'Are you sure you want to cancel all your open orders?',
 	},
 	AMOUNT_IN: 'Amount in',

--- a/web/src/config/lang/en.js
+++ b/web/src/config/lang/en.js
@@ -1441,7 +1441,7 @@ const nestedContent = {
 	CANCEL_ORDERS: {
 		HEADING: 'Cancel orders',
 		SUB_HEADING: 'Cancel all orders',
-		INFO_1: 'This will cancel your open orders for this markets.',
+		INFO_1: 'This will cancel your open orders for all markets.',
 		INFO_2: 'Are you sure you want to cancel all your open orders?',
 	},
 	AMOUNT_IN: 'Amount in',

--- a/web/src/containers/Trade/components/OrdersWrapper.js
+++ b/web/src/containers/Trade/components/OrdersWrapper.js
@@ -73,7 +73,7 @@ class OrdersWrapper extends Component {
 		const USER_TABS = [
 			{
 				stringId: 'ORDERS',
-				title: STRINGS['ORDERS'],
+				title: STRINGS['ORDERS'] + " (" + activeOrders.length + ")",
 				children: isLoggedIn() ? (
 					<ActiveOrders
 						pairData={pairData}

--- a/web/src/containers/Trade/components/OrdersWrapper.js
+++ b/web/src/containers/Trade/components/OrdersWrapper.js
@@ -73,7 +73,7 @@ class OrdersWrapper extends Component {
 		const USER_TABS = [
 			{
 				stringId: 'ORDERS',
-				title: STRINGS['ORDERS'] + " (" + activeOrders.length + ")",
+				title: `${STRINGS['ORDERS']} (${activeOrders.length})`,
 				children: isLoggedIn() ? (
 					<ActiveOrders
 						pairData={pairData}

--- a/web/src/containers/Trade/components/_TradeBlock.scss
+++ b/web/src/containers/Trade/components/_TradeBlock.scss
@@ -57,7 +57,7 @@ $tabs-title--margin: 2rem;
 
 .trade_block-wrapper {
 	padding: 1rem;
-	max-height: 500px;
+	max-height: 50rem;
 	// border: 1px solid $colors-main-border;
 	margin: 6px 3px 3px 3px;
 	background-color: $app-sidebar-background;

--- a/web/src/containers/Trade/components/_TradeBlock.scss
+++ b/web/src/containers/Trade/components/_TradeBlock.scss
@@ -57,6 +57,7 @@ $tabs-title--margin: 2rem;
 
 .trade_block-wrapper {
 	padding: 1rem;
+	max-height: 500px;
 	// border: 1px solid $colors-main-border;
 	margin: 6px 3px 3px 3px;
 	background-color: $app-sidebar-background;

--- a/web/src/containers/Trade/utils.js
+++ b/web/src/containers/Trade/utils.js
@@ -120,8 +120,7 @@ export const activeOrdersSelector = createSelector(
 	getActiveOrders,
 	getPair,
 	(orders, pair) => {
-		let count = 0;
-		return orders.filter(({ symbol }) => symbol === pair && count++ < 50);
+		return orders
 	}
 );
 


### PR DESCRIPTION
- Showing all active orders from any pair's trading dashboard
- Setting the max height for tab panels to keep them in a more user-friendly size 
- Adding the total number of active orders with the Active orders tab's title