### PR TITLE
User meta

### DIFF
--- a/server/api/swagger/swagger.yaml
+++ b/server/api/swagger/swagger.yaml
@@ -2127,7 +2127,7 @@ paths:
                 type: string
               type:
                 type: string
-                enum: [string, number, boolean, date]
+                enum: [string, number, boolean, date-time]
               required:
                 type: boolean
               description:
@@ -2163,7 +2163,7 @@ paths:
                 type: string
               type:
                 type: string
-                enum: [string, number, boolean, date]
+                enum: [string, number, boolean, date-time]
               required:
                 type: boolean
               description:
@@ -4142,7 +4142,7 @@ definitions:
       properties:
         type:
           type: string
-          enum: [string, number, boolean, date]
+          enum: [string, number, boolean, date-time]
         required:
           type: boolean
         description:

--- a/server/constants.js
+++ b/server/constants.js
@@ -149,7 +149,7 @@ exports.VALID_USER_META_TYPES = [
 	'string',
 	'number',
 	'boolean',
-	'date'
+	'date-time'
 ];
 
 exports.KIT_CONFIG_KEYS = [

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,7 @@
 		"geoip-lite": "1.4.1",
 		"helmet": "3.12.0",
 		"hollaex-node-lib": "github:bitholla/hollaex-node-lib#2.2",
-		"hollaex-tools-lib": "github:bitholla/hollaex-tools-lib#2.4",
+		"hollaex-tools-lib": "github:bitholla/hollaex-tools-lib#2.5",
 		"http": "0.0.0",
 		"install": "0.10.4",
 		"json2csv": "4.5.4",


### PR DESCRIPTION
user meta type `date` changed to `date-time` and only accepting ISO8601 format.

Tools library PR for branch [2.5](https://github.com/bitholla/hollaex-tools-lib/pull/38)